### PR TITLE
Get app ready for heroku (closes #45)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-workforwardnola.com

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rackup config.ru -p $PORT

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # workforwardnola
 Job seeker focused website for NOLA
 
-http://codeforamerica.github.io/workforwardnola/
+http://workforwardnola.com
+
+## Dev setup
+Requires Ruby 2.2.5
+
+After cloning the repository for the first time, run `bundle install` in the `workforwardnola` directory.
+
+Run the app by running `bin/start`. It will be available at [http://localhost:9292](http://localhost:9292). If there are errors when you try to refresh to see changes, try again - you may have been faster than the app regenerated.
+
+Deployment is via heroku. Staging: wfn-staging.herokuapp.com.


### PR DESCRIPTION
- add procfile
- delete CNAME file (not needed for heroku deploy)
- update README with new deploy/development info

We should probably add some sort of asset pipeline, I don't think it's precompiling anything right now. 
