### PR TITLE
update content via spreadsheet, closes #49

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .sass-cache
 .jekyll-metadata
 .env
+.DS_Store

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ namespace :db do
 
   desc 'Run DB migrations'
   task :migrate => :app do
+   puts 'Running migrations'
    Sequel::Migrator.apply(WorkForwardNola::App.database, 'db/migrations')
   end
 
@@ -29,6 +30,7 @@ namespace :db do
 
   desc 'Seed DB'
   task :seed => :app do
+    puts 'Running seed'
     require 'sequel/extensions/seed'
     Sequel.extension :seed
     Sequel::Seeder.apply(WorkForwardNola::App.database, 'db')
@@ -43,11 +45,5 @@ namespace :db do
   end
 
   desc 'Migrate & seed DB all in one'
-  task :setup => :app do
-    puts 'Running migrations'
-    Rake::Task['db:migrate'].execute
-    puts 'Running seed'
-    Rake::Task['db:seed'].execute
-    puts 'Done!'
-  end
+  task :setup => [:migrate, :seed]
 end

--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,10 @@ namespace :db do
 
   desc 'Migrate & seed DB all in one'
   task :setup => :app do
+    puts 'Running migrations'
     Rake::Task['db:migrate'].execute
+    puts 'Running seed'
     Rake::Task['db:seed'].execute
+    puts 'Done!'
   end
 end

--- a/app.json
+++ b/app.json
@@ -9,6 +9,12 @@
     },
     "RACK_ENV": {
       "required": true
+    },
+    "ADMIN_USER": {
+      "required": true
+    },
+    "ADMIN_PASSWORD": {
+      "required": true
     }
   },
   "formation": {

--- a/app.rb
+++ b/app.rb
@@ -53,5 +53,10 @@ module WorkForwardNola
       @title = 'Assessment'
       mustache :assessment
     end
+
+    get '/manage' do
+      @title = 'Manage Content'
+      mustache :manage
+    end
   end
 end

--- a/app.rb
+++ b/app.rb
@@ -38,6 +38,12 @@ module WorkForwardNola
       mustache :index
     end
 
+    post '/careers/update' do
+      data = JSON.parse(request.body.read)
+      puts data.to_s
+      {result: "success!! there are #{data.size} traits"}.to_json
+    end
+
     post '/careers' do
       # TODO require answers to all questions
       @quiz_answers = params       # params hash has answers

--- a/app.rb
+++ b/app.rb
@@ -13,6 +13,10 @@ module WorkForwardNola
       set :database, ENV['DATABASE_URL']
     end
 
+    # this is convoluted, but I have to require this after setting up the DB
+    require './models/trait'
+    require './models/career'
+
     # check for un-run migrations
     if ENV['RACK_ENV'].eql? 'development'
       Sequel.extension :migration
@@ -40,8 +44,10 @@ module WorkForwardNola
 
     post '/careers/update' do
       data = JSON.parse(request.body.read)
-      puts data.to_s
-      {result: "success!! there are #{data.size} traits"}.to_json
+      Trait.bulk_create data['traits']
+      Career.bulk_create data['careers']
+      {result: "success!! there are #{Trait.count} traits \
+      and #{Career.count} careers."}.to_json
     end
 
     post '/careers' do

--- a/app.rb
+++ b/app.rb
@@ -13,10 +13,6 @@ module WorkForwardNola
       set :database, ENV['DATABASE_URL']
     end
 
-    # this is convoluted, but I have to require this after setting up the DB
-    require './models/trait'
-    require './models/career'
-
     # check for un-run migrations
     if ENV['RACK_ENV'].eql? 'development'
       Sequel.extension :migration
@@ -48,6 +44,10 @@ module WorkForwardNola
 
     before do
       response.headers['Cache-Control'] = 'public, max-age=36000'
+      
+      # this is convoluted, but I have to require this after setting up the DB
+      require './models/trait'
+      require './models/career'
     end
 
     get '/' do

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -33,3 +33,15 @@ function showCareer(index) {
   $('#career-list').hide();
   $('[index='+index+']').show();
 }
+
+// jQuery POST using JSON
+$.postJSON = function(url, data, callback) {
+    return jQuery.ajax({
+        'type': 'POST',
+        'url': url,
+        'contentType': 'application/json; charset=utf-8',
+        'data': JSON.stringify(data),
+        'dataType': 'json',
+        'success': callback
+    });
+};

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -1,5 +1,5 @@
 //= require_directory ./vendor
-//
+//= require spreadsheets
 
 // custom JS can go in this file, or another, then you add another require line
 

--- a/assets/javascript/spreadsheets.js
+++ b/assets/javascript/spreadsheets.js
@@ -6,49 +6,56 @@ function checkSpreadsheetUrl() {
     spreadSheetKey,
     spreadSheetLink = event.target.value;
 
-    if(!spreadSheetLink){
-      console.log('link is empty');
-      // this.setState({
-        // linkStatus: 'empty',
-        // createButtonDisabled: true
-      // })
-      return;
-    }
+  if(!spreadSheetLink){
+    console.log('link is empty');
+    setState({
+      linkStatus: 'empty',
+      updateButtonDisabled: true
+    });
+    return;
+  }
 
-    if(/https:\/\/docs\.google\.com\/spreadsheets\/d\/(.*)\//.test(spreadSheetLink)){
-        console.log('link matches regex');
-        spreadSheetKey = spreadSheetLink.match(/https:\/\/docs\.google\.com\/spreadsheets\/d\/(.*)\//)[1];
+// https://docs.google.com/spreadsheets/d/1lMeZZ_vu-xIVKLgo7obKlF0X4iJ3oHkLKl8uIrPsSt8/pubhtml
 
-        // this.connectionSuccess = function(data){
-        //   console.log(spreadSheetKey)
-        //   this.setState({
-        //     linkStatus: 'success',
-        //     createButtonDisabled: false,
-        //     spreadSheetLink: spreadSheetKey
-        //   })
-        // }.bind(this)
+  if(/https:\/\/docs\.google\.com\/spreadsheets\/d\/(.*)\//.test(spreadSheetLink)){
+    console.log('link matches regex');
+    spreadSheetKey = spreadSheetLink.match(/https:\/\/docs\.google\.com\/spreadsheets\/d\/(.*)\//)[1];
 
-        // this.connectionError = function(err){
-        //   console.error('no connection!');
-        //   this.setState({
-        //     linkStatus: 'bad-connection',
-        //     createButtonDisabled: true
-        //   })
-        // }.bind(this)
+    this.connectionSuccess = function(data){
+      console.log(spreadSheetKey);
+      setState({
+        linkStatus: 'success',
+        updateButtonDisabled: false,
+        spreadSheetKey: spreadSheetKey
+      });
+    }.bind(this);
 
-        // $.get({
-        //   url: 'https://spreadsheets.google.com/feeds/list/' + spreadSheetKey + '/1/public/full?alt=json',
-        //   dataType: 'jsonp',
-        //   success: this.connectionSuccess,
-        //   error: this.connectionError
-        // });
+    this.connectionError = function(err){
+      console.error('no connection!');
+      setState({
+        linkStatus: 'bad-connection',
+        updateButtonDisabled: true
+      });
+    }.bind(this);
 
-      } else {
-        console.log('bad-format');
-        // this.setState({
-        //   linkStatus: 'bad-format',
-        //   createButtonDisabled: true
-        // })
-      }
+    $.get({
+      url: 'https://spreadsheets.google.com/feeds/list/' + spreadSheetKey + '/1/public/full?alt=json',
+      dataType: 'jsonp',
+      success: this.connectionSuccess,
+      error: this.connectionError
+    });
 
+  } else {
+    console.log('bad-format');
+    setState({
+      linkStatus: 'bad-format',
+      updateButtonDisabled: true
+    });
+  }
+}
+
+// see https://github.com/janl/mustache.js for possible alert-ing
+function setState(state /* linkStatus, updateButtonDisabled, spreadsheetKey */) {
+  console.log(state.linkStatus+', '+state.updateButtonDisabled+', '+state.spreadSheetKey);
+  $('button').prop('disabled', state.updateButtonDisabled);
 }

--- a/assets/javascript/spreadsheets.js
+++ b/assets/javascript/spreadsheets.js
@@ -1,0 +1,54 @@
+//'use strict';
+
+function checkSpreadsheetUrl() {
+  console.log($('[name="Spreadsheet URL"]').val());
+  var
+    spreadSheetKey,
+    spreadSheetLink = event.target.value;
+
+    if(!spreadSheetLink){
+      console.log('link is empty');
+      // this.setState({
+        // linkStatus: 'empty',
+        // createButtonDisabled: true
+      // })
+      return;
+    }
+
+    if(/https:\/\/docs\.google\.com\/spreadsheets\/d\/(.*)\//.test(spreadSheetLink)){
+        console.log('link matches regex');
+        spreadSheetKey = spreadSheetLink.match(/https:\/\/docs\.google\.com\/spreadsheets\/d\/(.*)\//)[1];
+
+        // this.connectionSuccess = function(data){
+        //   console.log(spreadSheetKey)
+        //   this.setState({
+        //     linkStatus: 'success',
+        //     createButtonDisabled: false,
+        //     spreadSheetLink: spreadSheetKey
+        //   })
+        // }.bind(this)
+
+        // this.connectionError = function(err){
+        //   console.error('no connection!');
+        //   this.setState({
+        //     linkStatus: 'bad-connection',
+        //     createButtonDisabled: true
+        //   })
+        // }.bind(this)
+
+        // $.get({
+        //   url: 'https://spreadsheets.google.com/feeds/list/' + spreadSheetKey + '/1/public/full?alt=json',
+        //   dataType: 'jsonp',
+        //   success: this.connectionSuccess,
+        //   error: this.connectionError
+        // });
+
+      } else {
+        console.log('bad-format');
+        // this.setState({
+        //   linkStatus: 'bad-format',
+        //   createButtonDisabled: true
+        // })
+      }
+
+}

--- a/assets/javascript/spreadsheets.js
+++ b/assets/javascript/spreadsheets.js
@@ -1,10 +1,9 @@
 //'use strict';
+var spreadSheetKey;
 
 function checkSpreadsheetUrl() {
   console.log($('[name="Spreadsheet URL"]').val());
-  var
-    spreadSheetKey,
-    spreadSheetLink = event.target.value;
+  var spreadSheetLink = event.target.value;
 
   if(!spreadSheetLink){
     console.log('link is empty');
@@ -54,8 +53,29 @@ function checkSpreadsheetUrl() {
   }
 }
 
-// see https://github.com/janl/mustache.js for possible alert-ing
-function setState(state /* linkStatus, updateButtonDisabled, spreadsheetKey */) {
+// see https://github.com/janl/mustache.js for possible flash/alert-ing
+function setState(state /* linkStatus, updateButtonDisabled, spreadSheetKey */) {
   console.log(state.linkStatus+', '+state.updateButtonDisabled+', '+state.spreadSheetKey);
   $('button').prop('disabled', state.updateButtonDisabled);
+}
+
+function updateFromSpreadsheet() {
+  if(spreadSheetKey) {
+    Tabletop.init({
+      key: spreadSheetKey,
+      callback: function (data, tabletop) {
+        uploadData(data, tabletop);
+        // update UI somehow (more flash messages probably)
+      }
+    });
+  } else {
+    console.log('no spreadsheet key! everything is terrible');
+  }
+}
+
+function uploadData(data, tabletop) {
+  // console.log(data.traits.all());
+  $.postJSON('/careers/update', data.traits.all(), callback = function(data) {
+    console.log('omg '+data.result);
+  });
 }

--- a/assets/javascript/spreadsheets.js
+++ b/assets/javascript/spreadsheets.js
@@ -1,9 +1,8 @@
-//'use strict';
+'use strict';
 var spreadSheetKey;
 
 function checkSpreadsheetUrl() {
-  console.log($('[name="Spreadsheet URL"]').val());
-  var spreadSheetLink = event.target.value;
+  var spreadSheetLink = $('[name="Spreadsheet URL"]').val();
 
   if(!spreadSheetLink){
     console.log('link is empty');
@@ -74,7 +73,6 @@ function updateFromSpreadsheet() {
 }
 
 function uploadData(data, tabletop) {
-  // console.log(data.traits.all());
   var dataToSend = {};
   dataToSend.traits = data.traits.all();
   dataToSend.careers = data.careers.all();

--- a/assets/javascript/spreadsheets.js
+++ b/assets/javascript/spreadsheets.js
@@ -75,7 +75,11 @@ function updateFromSpreadsheet() {
 
 function uploadData(data, tabletop) {
   // console.log(data.traits.all());
-  $.postJSON('/careers/update', data.traits.all(), callback = function(data) {
+  var dataToSend = {};
+  dataToSend.traits = data.traits.all();
+  dataToSend.careers = data.careers.all();
+
+  $.postJSON('/careers/update', dataToSend, callback = function(data) {
     console.log('omg '+data.result);
   });
 }

--- a/assets/javascript/vendor/tabletop.js
+++ b/assets/javascript/vendor/tabletop.js
@@ -1,0 +1,568 @@
+(function() {
+  "use strict";
+
+  var inNodeJS = false;
+  if (typeof process !== 'undefined' && !process.browser) {
+    inNodeJS = true;
+    var request = require('request'.trim()); //prevents browserify from bundling the module
+  }
+
+  var supportsCORS = false;
+  var inLegacyIE = false;
+  try {
+    var testXHR = new XMLHttpRequest();
+    if (typeof testXHR.withCredentials !== 'undefined') {
+      supportsCORS = true;
+    } else {
+      if ("XDomainRequest" in window) {
+        supportsCORS = true;
+        inLegacyIE = true;
+      }
+    }
+  } catch (e) { }
+
+  // Create a simple indexOf function for support
+  // of older browsers.  Uses native indexOf if 
+  // available.  Code similar to underscores.
+  // By making a separate function, instead of adding
+  // to the prototype, we will not break bad for loops
+  // in older browsers
+  var indexOfProto = Array.prototype.indexOf;
+  var ttIndexOf = function(array, item) {
+    var i = 0, l = array.length;
+    
+    if (indexOfProto && array.indexOf === indexOfProto) return array.indexOf(item);
+    for (; i < l; i++) if (array[i] === item) return i;
+    return -1;
+  };
+  
+  /*
+    Initialize with Tabletop.init( { key: '0AjAPaAU9MeLFdHUxTlJiVVRYNGRJQnRmSnQwTlpoUXc' } )
+      OR!
+    Initialize with Tabletop.init( { key: 'https://docs.google.com/spreadsheet/pub?hl=en_US&hl=en_US&key=0AjAPaAU9MeLFdHUxTlJiVVRYNGRJQnRmSnQwTlpoUXc&output=html&widget=true' } )
+      OR!
+    Initialize with Tabletop.init('0AjAPaAU9MeLFdHUxTlJiVVRYNGRJQnRmSnQwTlpoUXc')
+  */
+
+  var Tabletop = function(options) {
+    // Make sure Tabletop is being used as a constructor no matter what.
+    if(!this || !(this instanceof Tabletop)) {
+      return new Tabletop(options);
+    }
+    
+    if(typeof(options) === 'string') {
+      options = { key : options };
+    }
+
+    this.callback = options.callback;
+    this.wanted = options.wanted || [];
+    this.key = options.key;
+    this.simpleSheet = !!options.simpleSheet;
+    this.parseNumbers = !!options.parseNumbers;
+    this.wait = !!options.wait;
+    this.reverse = !!options.reverse;
+    this.postProcess = options.postProcess;
+    this.debug = !!options.debug;
+    this.query = options.query || '';
+    this.orderby = options.orderby;
+    this.endpoint = options.endpoint || "https://spreadsheets.google.com";
+    this.singleton = !!options.singleton;
+    this.simple_url = !!options.simple_url;
+    this.callbackContext = options.callbackContext;
+    // Default to on, unless there's a proxy, in which case it's default off
+    this.prettyColumnNames = typeof(options.prettyColumnNames) == 'undefined' ? !options.proxy : options.prettyColumnNames
+    
+    if(typeof(options.proxy) !== 'undefined') {
+      // Remove trailing slash, it will break the app
+      this.endpoint = options.proxy.replace(/\/$/,'');
+      this.simple_url = true;
+      this.singleton = true;
+      // Let's only use CORS (straight JSON request) when
+      // fetching straight from Google
+      supportsCORS = false;
+    }
+    
+    this.parameterize = options.parameterize || false;
+    
+    if(this.singleton) {
+      if(typeof(Tabletop.singleton) !== 'undefined') {
+        this.log("WARNING! Tabletop singleton already defined");
+      }
+      Tabletop.singleton = this;
+    }
+    
+    /* Be friendly about what you accept */
+    if(/key=/.test(this.key)) {
+      this.log("You passed an old Google Docs url as the key! Attempting to parse.");
+      this.key = this.key.match("key=(.*?)(&|#|$)")[1];
+    }
+
+    if(/pubhtml/.test(this.key)) {
+      this.log("You passed a new Google Spreadsheets url as the key! Attempting to parse.");
+      this.key = this.key.match("d\\/(.*?)\\/pubhtml")[1];
+    }
+
+    if(!this.key) {
+      this.log("You need to pass Tabletop a key!");
+      return;
+    }
+
+    this.log("Initializing with key " + this.key);
+
+    this.models = {};
+    this.model_names = [];
+
+    this.base_json_path = "/feeds/worksheets/" + this.key + "/public/basic?alt=";
+
+    if (inNodeJS || supportsCORS) {
+      this.base_json_path += 'json';
+    } else {
+      this.base_json_path += 'json-in-script';
+    }
+    
+    if(!this.wait) {
+      this.fetch();
+    }
+  };
+
+  // A global storage for callbacks.
+  Tabletop.callbacks = {};
+
+  // Backwards compatibility.
+  Tabletop.init = function(options) {
+    return new Tabletop(options);
+  };
+
+  Tabletop.sheets = function() {
+    this.log("Times have changed! You'll want to use var tabletop = Tabletop.init(...); tabletop.sheets(...); instead of Tabletop.sheets(...)");
+  };
+
+  Tabletop.prototype = {
+
+    fetch: function(callback) {
+      if(typeof(callback) !== "undefined") {
+        this.callback = callback;
+      }
+      this.requestData(this.base_json_path, this.loadSheets);
+    },
+    
+    /*
+      This will call the environment appropriate request method.
+      
+      In browser it will use JSON-P, in node it will use request()
+    */
+    requestData: function(path, callback) {
+      if (inNodeJS) {
+        this.serverSideFetch(path, callback);
+      } else {
+        //CORS only works in IE8/9 across the same protocol
+        //You must have your server on HTTPS to talk to Google, or it'll fall back on injection
+        var protocol = this.endpoint.split("//").shift() || "http";
+        if (supportsCORS && (!inLegacyIE || protocol === location.protocol)) {
+          this.xhrFetch(path, callback);
+        } else {
+          this.injectScript(path, callback);
+        }
+      }
+    },
+
+    /*
+      Use Cross-Origin XMLHttpRequest to get the data in browsers that support it.
+    */
+    xhrFetch: function(path, callback) {
+      //support IE8's separate cross-domain object
+      var xhr = inLegacyIE ? new XDomainRequest() : new XMLHttpRequest();
+      xhr.open("GET", this.endpoint + path);
+      var self = this;
+      xhr.onload = function() {
+        try {
+          var json = JSON.parse(xhr.responseText);
+        } catch (e) {
+          console.error(e);
+        }
+        callback.call(self, json);
+      };
+      xhr.send();
+    },
+    
+    /*
+      Insert the URL into the page as a script tag. Once it's loaded the spreadsheet data
+      it triggers the callback. This helps you avoid cross-domain errors
+      http://code.google.com/apis/gdata/samples/spreadsheet_sample.html
+
+      Let's be plain-Jane and not use jQuery or anything.
+    */
+    injectScript: function(path, callback) {
+      var script = document.createElement('script');
+      var callbackName;
+      
+      if(this.singleton) {
+        if(callback === this.loadSheets) {
+          callbackName = 'Tabletop.singleton.loadSheets';
+        } else if (callback === this.loadSheet) {
+          callbackName = 'Tabletop.singleton.loadSheet';
+        }
+      } else {
+        var self = this;
+        callbackName = 'tt' + (+new Date()) + (Math.floor(Math.random()*100000));
+        // Create a temp callback which will get removed once it has executed,
+        // this allows multiple instances of Tabletop to coexist.
+        Tabletop.callbacks[ callbackName ] = function () {
+          var args = Array.prototype.slice.call( arguments, 0 );
+          callback.apply(self, args);
+          script.parentNode.removeChild(script);
+          delete Tabletop.callbacks[callbackName];
+        };
+        callbackName = 'Tabletop.callbacks.' + callbackName;
+      }
+      
+      var url = path + "&callback=" + callbackName;
+      
+      if(this.simple_url) {
+        // We've gone down a rabbit hole of passing injectScript the path, so let's
+        // just pull the sheet_id out of the path like the least efficient worker bees
+        if(path.indexOf("/list/") !== -1) {
+          script.src = this.endpoint + "/" + this.key + "-" + path.split("/")[4];
+        } else {
+          script.src = this.endpoint + "/" + this.key;
+        }
+      } else {
+        script.src = this.endpoint + url;
+      }
+      
+      if (this.parameterize) {
+        script.src = this.parameterize + encodeURIComponent(script.src);
+      }
+      
+      document.getElementsByTagName('script')[0].parentNode.appendChild(script);
+    },
+    
+    /* 
+      This will only run if tabletop is being run in node.js
+    */
+    serverSideFetch: function(path, callback) {
+      var self = this
+      request({url: this.endpoint + path, json: true}, function(err, resp, body) {
+        if (err) {
+          return console.error(err);
+        }
+        callback.call(self, body);
+      });
+    },
+
+    /* 
+      Is this a sheet you want to pull?
+      If { wanted: ["Sheet1"] } has been specified, only Sheet1 is imported
+      Pulls all sheets if none are specified
+    */
+    isWanted: function(sheetName) {
+      if(this.wanted.length === 0) {
+        return true;
+      } else {
+        return (ttIndexOf(this.wanted, sheetName) !== -1);
+      }
+    },
+    
+    /*
+      What gets send to the callback
+      if simpleSheet === true, then don't return an array of Tabletop.this.models,
+      only return the first one's elements
+    */
+    data: function() {
+      // If the instance is being queried before the data's been fetched
+      // then return undefined.
+      if(this.model_names.length === 0) {
+        return undefined;
+      }
+      if(this.simpleSheet) {
+        if(this.model_names.length > 1 && this.debug) {
+          this.log("WARNING You have more than one sheet but are using simple sheet mode! Don't blame me when something goes wrong.");
+        }
+        return this.models[ this.model_names[0] ].all();
+      } else {
+        return this.models;
+      }
+    },
+
+    /*
+      Add another sheet to the wanted list
+    */
+    addWanted: function(sheet) {
+      if(ttIndexOf(this.wanted, sheet) === -1) {
+        this.wanted.push(sheet);
+      }
+    },
+    
+    /*
+      Load all worksheets of the spreadsheet, turning each into a Tabletop Model.
+      Need to use injectScript because the worksheet view that you're working from
+      doesn't actually include the data. The list-based feed (/feeds/list/key..) does, though.
+      Calls back to loadSheet in order to get the real work done.
+
+      Used as a callback for the worksheet-based JSON
+    */
+    loadSheets: function(data) {
+      var i, ilen;
+      var toLoad = [];
+      this.googleSheetName = data.feed.title.$t;
+      this.foundSheetNames = [];
+
+      for(i = 0, ilen = data.feed.entry.length; i < ilen ; i++) {
+        this.foundSheetNames.push(data.feed.entry[i].title.$t);
+        // Only pull in desired sheets to reduce loading
+        if( this.isWanted(data.feed.entry[i].content.$t) ) {
+          var linkIdx = data.feed.entry[i].link.length-1;
+          var sheet_id = data.feed.entry[i].link[linkIdx].href.split('/').pop();
+          var json_path = "/feeds/list/" + this.key + "/" + sheet_id + "/public/values?alt="
+          if (inNodeJS || supportsCORS) {
+            json_path += 'json';
+          } else {
+            json_path += 'json-in-script';
+          }
+          if(this.query) {
+            json_path += "&sq=" + this.query;
+          }
+          if(this.orderby) {
+            json_path += "&orderby=column:" + this.orderby.toLowerCase();
+          }
+          if(this.reverse) {
+            json_path += "&reverse=true";
+          }
+          toLoad.push(json_path);
+        }
+      }
+
+      this.sheetsToLoad = toLoad.length;
+      for(i = 0, ilen = toLoad.length; i < ilen; i++) {
+        this.requestData(toLoad[i], this.loadSheet);
+      }
+    },
+
+    /*
+      Access layer for the this.models
+      .sheets() gets you all of the sheets
+      .sheets('Sheet1') gets you the sheet named Sheet1
+    */
+    sheets: function(sheetName) {
+      if(typeof sheetName === "undefined") {
+        return this.models;
+      } else {
+        if(typeof(this.models[ sheetName ]) === "undefined") {
+          // alert( "Can't find " + sheetName );
+          return;
+        } else {
+          return this.models[ sheetName ];
+        }
+      }
+    },
+
+    sheetReady: function(model) {
+      this.models[ model.name ] = model;
+      if(ttIndexOf(this.model_names, model.name) === -1) {
+        this.model_names.push(model.name);
+      }
+
+      this.sheetsToLoad--;
+      if(this.sheetsToLoad === 0)
+        this.doCallback();
+    },
+    
+    /*
+      Parse a single list-based worksheet, turning it into a Tabletop Model
+
+      Used as a callback for the list-based JSON
+    */
+    loadSheet: function(data) {
+      var that = this;
+      var model = new Tabletop.Model( { data: data, 
+                                        parseNumbers: this.parseNumbers,
+                                        postProcess: this.postProcess,
+                                        tabletop: this,
+                                        prettyColumnNames: this.prettyColumnNames,
+                                        onReady: function() {
+                                          that.sheetReady(this);
+                                        } } );
+    },
+
+    /*
+      Execute the callback upon loading! Rely on this.data() because you might
+        only request certain pieces of data (i.e. simpleSheet mode)
+      Tests this.sheetsToLoad just in case a race condition happens to show up
+    */
+    doCallback: function() {
+      if(this.sheetsToLoad === 0) {
+        this.callback.apply(this.callbackContext || this, [this.data(), this]);
+      }
+    },
+
+    log: function(msg) {
+      if(this.debug) {
+        if(typeof console !== "undefined" && typeof console.log !== "undefined") {
+          Function.prototype.apply.apply(console.log, [console, arguments]);
+        }
+      }
+    }
+
+  };
+
+  /*
+    Tabletop.Model stores the attribute names and parses the worksheet data
+      to turn it into something worthwhile
+
+    Options should be in the format { data: XXX }, with XXX being the list-based worksheet
+  */
+  Tabletop.Model = function(options) {
+    var i, j, ilen, jlen;
+    this.column_names = [];
+    this.name = options.data.feed.title.$t;
+    this.tabletop = options.tabletop;
+    this.elements = [];
+    this.onReady = options.onReady;
+    this.raw = options.data; // A copy of the sheet's raw data, for accessing minutiae
+
+    if(typeof(options.data.feed.entry) === 'undefined') {
+      options.tabletop.log("Missing data for " + this.name + ", make sure you didn't forget column headers");
+      this.original_columns = [];
+      this.elements = [];
+      this.onReady.call(this);
+      return;
+    }
+    
+    for(var key in options.data.feed.entry[0]){
+      if(/^gsx/.test(key))
+        this.column_names.push( key.replace("gsx$","") );
+    }
+
+    this.original_columns = this.column_names;
+    
+    for(i = 0, ilen =  options.data.feed.entry.length ; i < ilen; i++) {
+      var source = options.data.feed.entry[i];
+      var element = {};
+      for(var j = 0, jlen = this.column_names.length; j < jlen ; j++) {
+        var cell = source[ "gsx$" + this.column_names[j] ];
+        if (typeof(cell) !== 'undefined') {
+          if(options.parseNumbers && cell.$t !== '' && !isNaN(cell.$t))
+            element[ this.column_names[j] ] = +cell.$t;
+          else
+            element[ this.column_names[j] ] = cell.$t;
+        } else {
+            element[ this.column_names[j] ] = '';
+        }
+      }
+      if(element.rowNumber === undefined)
+        element.rowNumber = i + 1;
+      if( options.postProcess )
+        options.postProcess(element);
+      this.elements.push(element);
+    }
+    
+    if(options.prettyColumnNames)
+      this.fetchPrettyColumns();
+    else
+      this.onReady.call(this);
+  };
+
+  Tabletop.Model.prototype = {
+    /*
+      Returns all of the elements (rows) of the worksheet as objects
+    */
+    all: function() {
+      return this.elements;
+    },
+    
+    fetchPrettyColumns: function() {
+      if(!this.raw.feed.link[3])
+        return this.ready();
+      var cellurl = this.raw.feed.link[3].href.replace('/feeds/list/', '/feeds/cells/').replace('https://spreadsheets.google.com', '');
+      var that = this;
+      this.tabletop.requestData(cellurl, function(data) {
+        that.loadPrettyColumns(data)
+      });
+    },
+    
+    ready: function() {
+      this.onReady.call(this);
+    },
+    
+    /*
+     * Store column names as an object
+     * with keys of Google-formatted "columnName"
+     * and values of human-readable "Column name"
+     */
+    loadPrettyColumns: function(data) {
+      var pretty_columns = {};
+
+      var column_names = this.column_names;
+
+      var i = 0;
+      var l = column_names.length;
+
+      for (; i < l; i++) {
+        if (typeof data.feed.entry[i].content.$t !== 'undefined') {
+          pretty_columns[column_names[i]] = data.feed.entry[i].content.$t;
+        } else {
+          pretty_columns[column_names[i]] = column_names[i];
+        }
+      }
+
+      this.pretty_columns = pretty_columns;
+
+      this.prettifyElements();
+      this.ready();
+    },
+    
+    /*
+     * Go through each row, substitutiting
+     * Google-formatted "columnName"
+     * with human-readable "Column name"
+     */
+    prettifyElements: function() {
+      var pretty_elements = [],
+          ordered_pretty_names = [],
+          i, j, ilen, jlen;
+
+      var ordered_pretty_names;
+      for(j = 0, jlen = this.column_names.length; j < jlen ; j++) {
+        ordered_pretty_names.push(this.pretty_columns[this.column_names[j]]);
+      }
+
+      for(i = 0, ilen = this.elements.length; i < ilen; i++) {
+        var new_element = {};
+        for(j = 0, jlen = this.column_names.length; j < jlen ; j++) {
+          var new_column_name = this.pretty_columns[this.column_names[j]];
+          new_element[new_column_name] = this.elements[i][this.column_names[j]];
+        }
+        pretty_elements.push(new_element);
+      }
+      this.elements = pretty_elements;
+      this.column_names = ordered_pretty_names;
+    },
+
+    /*
+      Return the elements as an array of arrays, instead of an array of objects
+    */
+    toArray: function() {
+      var array = [],
+          i, j, ilen, jlen;
+      for(i = 0, ilen = this.elements.length; i < ilen; i++) {
+        var row = [];
+        for(j = 0, jlen = this.column_names.length; j < jlen ; j++) {
+          row.push( this.elements[i][ this.column_names[j] ] );
+        }
+        array.push(row);
+      }
+      return array;
+    }
+  };
+
+  if(typeof module !== "undefined" && module.exports) { //don't just use inNodeJS, we may be in Browserify
+    module.exports = Tabletop;
+  } else if (typeof define === 'function' && define.amd) {
+    define(function () {
+        return Tabletop;
+    });
+  } else {
+    window.Tabletop = Tabletop;
+  }
+
+})();

--- a/assets/style/_buttons.scss
+++ b/assets/style/_buttons.scss
@@ -5,7 +5,7 @@ $button-stroke: inset 0 0 0 2px;
 // Buttons
 
 // scss-lint:disable PropertyCount
-.button-wrapper{padding:.5em 0 !important;}
+.button-wrapper { padding: .5em 0 !important; }
 
 .basic-button,
 .basic-button-primary,
@@ -90,6 +90,24 @@ button,
       border-bottom: 0;
       text-decoration: none;
     }
+  }
+}
+
+[type='submit']:disabled,
+.basic-button-disabled {
+  background-color: $light-gray;
+  color: $dark-gray;
+  pointer-events: none;
+
+  &:hover,
+  &.basic-button-hover,
+  &:active,
+  &.basic-button-active,
+  &:focus {
+    background-color: $light-gray;
+    border: 0;
+    box-shadow: none;
+    color: $dark-gray;
   }
 }
 

--- a/assets/style/_manage.scss
+++ b/assets/style/_manage.scss
@@ -1,0 +1,28 @@
+$base-spacing: 1.5em !default;
+$flashes: (
+  'alert': #fff6bf,
+  'error': #fbe3e4,
+  'notice': #e5edf8,
+  'success': #e6efc2,
+) !default;
+
+@each $flash-type, $color in $flashes {
+  .flash-#{$flash-type} {
+    background-color: $color;
+    color: shade($color, 60%);
+    display: block;
+    margin-bottom: $base-spacing / 2;
+    padding: $base-spacing / 2;
+    text-align: center;
+
+    a {
+      color: shade($color, 70%);
+      text-decoration: underline;
+
+      &:focus,
+      &:hover {
+        color: shade($color, 90%);
+      }
+    }
+  }
+}

--- a/assets/style/main.scss
+++ b/assets/style/main.scss
@@ -3,6 +3,7 @@
 @import 'variables';
 @import 'buttons';
 @import 'assessment';
+@import 'manage';
 
 .clearfix {
   overflow: auto;

--- a/db/20160722_seeds.rb
+++ b/db/20160722_seeds.rb
@@ -4,6 +4,9 @@ module WorkForwardNola
 
   Sequel.seed do
     def run
+
+      Trait.set_allowed_columns :name
+
       [
         'Detail oriented',
         'Working with your hands',

--- a/db/migrations/002_add_column_spreadsheetkey_to_traits.rb
+++ b/db/migrations/002_add_column_spreadsheetkey_to_traits.rb
@@ -1,0 +1,7 @@
+Sequel.migration do 
+  change do
+    alter_table(:traits) do
+      add_column :spreadsheet_key, Integer
+    end
+  end
+end

--- a/models/career.rb
+++ b/models/career.rb
@@ -1,5 +1,30 @@
 module WorkForwardNola
   class Career < Sequel::Model
     many_to_many :traits
+
+    def self.bulk_create data
+      # clear careers table
+      Career.db.run 'TRUNCATE careers CASCADE'
+      # iterate over data & insert for each one
+      all_traits = Trait.map { |t| [t[:spreadsheet_key] , t[:id]] }.to_h
+      puts all_traits
+      data.each do |career|
+        new_career = Career.create(
+          name: career['name'],
+          sector: career['sector'],
+          experienced_wage: career['experienced_wage'],
+          ## this is a hack, we need to have the data ##
+          average_wage: (career['average_wage'].empty? ? -1 : career['average_wage']),
+          training_money_available: career['training_money_available'],
+          certification_required: career['certification_required'],
+          description: career['description'])
+        # add traits
+        career['traits'].split(',').each do |spreadsheet_key|
+          puts spreadsheet_key
+          puts all_traits[spreadsheet_key.to_i]
+          new_career.add_trait all_traits[spreadsheet_key.to_i]
+        end
+      end
+    end
   end
 end

--- a/models/career.rb
+++ b/models/career.rb
@@ -7,7 +7,7 @@ module WorkForwardNola
       Career.db.run 'TRUNCATE careers CASCADE'
       # iterate over data & insert for each one
       all_traits = Trait.map { |t| [t[:spreadsheet_key] , t[:id]] }.to_h
-      puts all_traits
+
       data.each do |career|
         new_career = Career.create(
           name: career['name'],
@@ -18,10 +18,9 @@ module WorkForwardNola
           training_money_available: career['training_money_available'],
           certification_required: career['certification_required'],
           description: career['description'])
+
         # add traits
         career['traits'].split(',').each do |spreadsheet_key|
-          puts spreadsheet_key
-          puts all_traits[spreadsheet_key.to_i]
           new_career.add_trait all_traits[spreadsheet_key.to_i]
         end
       end

--- a/models/trait.rb
+++ b/models/trait.rb
@@ -4,7 +4,7 @@ module WorkForwardNola
 
     def self.bulk_create data
       # clear traits table
-      Trait.db.run 'TRUNCATE traits, careers_traits'
+      Trait.db.run 'TRUNCATE traits CASCADE'
       # iterate over data & insert for each one
       data.each do |trait|
         Trait.create name: trait['name'], spreadsheet_key: trait['id']

--- a/models/trait.rb
+++ b/models/trait.rb
@@ -1,5 +1,14 @@
 module WorkForwardNola
   class Trait < Sequel::Model
     many_to_many :careers
+
+    def self.bulk_create data
+      # clear traits table
+      Trait.db.run 'TRUNCATE traits, careers_traits'
+      # iterate over data & insert for each one
+      data.each do |trait|
+        Trait.create name: trait['name'], spreadsheet_key: trait['id']
+      end
+    end
   end
 end

--- a/templates/manage.mustache
+++ b/templates/manage.mustache
@@ -1,0 +1,12 @@
+  <div class="centered">
+    <h1>Manage careers content</h1>
+    <form action="/careers/update" method="POST">
+      <label>Google Spreadsheet URL: </label>
+      <input name="Spreadsheet URL" placeholder="Spreadsheet URL" type="text" onchange="checkSpreadsheetUrl()" />
+      <div class="button-wrapper">
+        <button class="basic-button" type="submit" disabled>Update content</button>
+      </div>
+    </form>
+
+    <p>Coming soon: how to set up a spreadsheet for the content</p>
+  </div>

--- a/templates/manage.mustache
+++ b/templates/manage.mustache
@@ -1,6 +1,5 @@
   <div class="centered">
     <h1>Manage careers content</h1>
-    {{! <form action="/careers/update" method="POST"> }}
       <label>Google Spreadsheet URL: </label>
       <input name="Spreadsheet URL" placeholder="Spreadsheet URL" type="text" onchange="checkSpreadsheetUrl()" />
       {{! <div class="flash-success" id="alert">
@@ -9,7 +8,8 @@
       <div class="button-wrapper">
         <button class="basic-button" type="submit" onclick="updateFromSpreadsheet()" disabled>Update content</button>
       </div>
-    {{! </form> }}
 
-    <p>Coming soon: how to set up a spreadsheet for the content</p>
+    <p>If you're starting from scratch, <a href="https://drive.google.com/previewtemplate?id=1vgqsoXLJ9FSDZamGv-SzDX_xCV3wHY0Lh142nhuZDQI&mode=public">use this template</a>. After all your data is in, publish it to the web ("File" > "Publish to Web" and use that url above.</p>
+    <p>If you're working with Code for America, use <a href="https://docs.google.com/spreadsheets/d/1lMeZZ_vu-xIVKLgo7obKlF0X4iJ3oHkLKl8uIrPsSt8/pubhtml">this url</a>.</p>
+    <p>DO NOT modify any column names on the 'careers' or 'traits' tabs, the data will not update correctly. DO fill out every column.</p>
   </div>

--- a/templates/manage.mustache
+++ b/templates/manage.mustache
@@ -3,6 +3,9 @@
     <form action="/careers/update" method="POST">
       <label>Google Spreadsheet URL: </label>
       <input name="Spreadsheet URL" placeholder="Spreadsheet URL" type="text" onchange="checkSpreadsheetUrl()" />
+      {{! <div class="flash-success" id="alert">
+        <span>This is a success message <a href="#">with a link</a></span>
+       </div>}}
       <div class="button-wrapper">
         <button class="basic-button" type="submit" disabled>Update content</button>
       </div>

--- a/templates/manage.mustache
+++ b/templates/manage.mustache
@@ -1,15 +1,15 @@
   <div class="centered">
     <h1>Manage careers content</h1>
-    <form action="/careers/update" method="POST">
+    {{! <form action="/careers/update" method="POST"> }}
       <label>Google Spreadsheet URL: </label>
       <input name="Spreadsheet URL" placeholder="Spreadsheet URL" type="text" onchange="checkSpreadsheetUrl()" />
       {{! <div class="flash-success" id="alert">
         <span>This is a success message <a href="#">with a link</a></span>
        </div>}}
       <div class="button-wrapper">
-        <button class="basic-button" type="submit" disabled>Update content</button>
+        <button class="basic-button" type="submit" onclick="updateFromSpreadsheet()" disabled>Update content</button>
       </div>
-    </form>
+    {{! </form> }}
 
     <p>Coming soon: how to set up a spreadsheet for the content</p>
   </div>

--- a/views/manage.rb
+++ b/views/manage.rb
@@ -1,0 +1,7 @@
+module WorkForwardNola
+  module Views
+    class Manage < Layout
+      attr_reader :title
+    end
+  end
+end


### PR DESCRIPTION
Given a [published spreadsheet of the correct format](https://docs.google.com/spreadsheets/d/1lMeZZ_vu-xIVKLgo7obKlF0X4iJ3oHkLKl8uIrPsSt8/pubhtml), replace all the traits & career data with the contents of the spreadsheet.

Related issues from work left undone:
- prettier error handling for spreadsheet #67
- meaningful responses from `/careers/update` #68
- fix build...

Also note that this PR requires running `rake db:migrate`.
